### PR TITLE
chore: update Velopack and increment assembly version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       PROJECT: ResoniteModUpdater
       DOTNET_VERSION: '8.0.x'
-      VPK_VERSION: '0.0.626'
+      VPK_VERSION: '0.0.1053'
       DOTNET_NOLOGO: true
 
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         run: vpk download github --repoUrl ${{ github.server_url }}/${{ github.repository }} --channel ${{ matrix.platform }}${{ matrix.is-portable && '-portable' || '' }} -o releases
 
       - name: Pack New Release
-        run: vpk -y ${{ startsWith(matrix.platform, 'win') && '[win] ' || '' }}pack -u ${{ env.PROJECT }} -v ${{ steps.get-version.outputs.version }} -r ${{ matrix.platform }} --channel ${{ matrix.platform }}${{ matrix.is-portable && '-portable' || '' }} ${{ matrix.extra-args }} -p publish/${{ matrix.platform }}${{ matrix.is-portable && '-portable' || '' }} -o releases
+        run: vpk ${{ startsWith(matrix.platform, 'win') && '[win] ' || '' }}pack -u ${{ env.PROJECT }} -v ${{ steps.get-version.outputs.version }} -r ${{ matrix.platform }} --channel ${{ matrix.platform }}${{ matrix.is-portable && '-portable' || '' }} ${{ matrix.extra-args }} -p publish/${{ matrix.platform }}${{ matrix.is-portable && '-portable' || '' }} -o releases
 
       - name: Rename and Update Portable Package
         if: matrix.is-portable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       PROJECT: ResoniteModUpdater
       DOTNET_VERSION: '8.0.x'
-      VPK_VERSION: '0.0.626'
+      VPK_VERSION: '0.0.1053'
       DOTNET_NOLOGO: true
 
     strategy:

--- a/ResoniteModUpdater/ResoniteModUpdater.csproj
+++ b/ResoniteModUpdater/ResoniteModUpdater.csproj
@@ -9,7 +9,7 @@
     <Authors>hazre</Authors>
     <RepositoryUrl>https://github.com/hazre/ResoniteModUpdater</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <AssemblyVersion>2.3.1</AssemblyVersion>
+    <AssemblyVersion>2.3.2</AssemblyVersion>
     <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
@@ -27,7 +27,7 @@
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageReference Include="System.ServiceModel.Syndication" Version="8.0.0" />
-    <PackageReference Include="Velopack" Version="0.0.626" />
+    <PackageReference Include="Velopack" Version="0.0.1053" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Makes sure dotnet cdn url change won't break the auto installer in the future.